### PR TITLE
add Node Security Platform (NSP) support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ node_js:
   - '4.4'
 before_install:
   - npm install -g npm@2.13.5
+  - npm install -g nsp
 install: npm install
 services:
   - docker
 script:
   - npm test
+  - nsp check
   - bash <(curl https://gist.githubusercontent.com/feedhenry-raincacher/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 notifications:
   email: false


### PR DESCRIPTION
Motivation:
To help identify/discover known vulnerabilities in this project.

Modifications:
Added nsp to the CI configuration (Travis).

Result:
nsp check will be run as part of CI

JIRA:
https://issues.jboss.org/browse/RAINCATCH-202
